### PR TITLE
Fix build error for useParams import

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Routes, Route, Navigate } from 'react-router-dom';
 import { Analytics } from '@vercel/analytics/react';
-import { SpeedInsights } from "@vercel/speed-insights/next"
+import { SpeedInsights } from "@vercel/speed-insights/react"
 import { Layout } from './components/layout';
 import { Dashboard } from './pages/dashboard';
 import { People } from './pages/members';
@@ -35,6 +35,7 @@ function App() {
   return (
     <>
       <Analytics />
+      <SpeedInsights />
       <Routes>
         {/* Public routes */}
         <Route path="/" element={<PublicLayout><Login /></PublicLayout>} />


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Update Vercel Speed Insights import to use the React-specific package to resolve a build error.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The build was failing because the `@vercel/speed-insights/next` package, designed for Next.js, was being used in a Vite/React project, leading to an error about missing `useParams` from `next/navigation.js`. Switching to `@vercel/speed-insights/react` resolves this compatibility issue.