### PR TITLE
Understand and fix reference error

### DIFF
--- a/frontend/src/pages/member-profile.jsx
+++ b/frontend/src/pages/member-profile.jsx
@@ -13,6 +13,7 @@ import {
   Clock,
   Church,
   User,
+  Baby,
   Trash2,
   Plus,
   Calendar as CalendarIcon,


### PR DESCRIPTION
Add `Baby` icon import to resolve `ReferenceError`.

The `Baby` icon component was being used in `member-profile.jsx` to display a child indicator badge, but it was not imported from `lucide-react`, causing a `ReferenceError: Baby is not defined`.