### PR TITLE
Remove manage members button from children's checking

### DIFF
--- a/frontend/src/pages/children-checkin.jsx
+++ b/frontend/src/pages/children-checkin.jsx
@@ -383,12 +383,6 @@ export default function ChildrenCheckin() {
           >
             Add Child
           </a>
-          <a
-            href="/members"
-            className="flex-1 md:flex-none bg-secondary text-secondary-foreground px-6 md:px-6 py-3 md:py-3 rounded-lg text-lg md:text-lg font-medium hover:bg-secondary/90 h-14 md:h-14 flex items-center justify-center transition-colors"
-          >
-            Manage Members
-          </a>
         </div>
       </div>
 


### PR DESCRIPTION
Remove the "Manage Members" button from the children's checking page as per user request.

---
<a href="https://cursor.com/background-agent?bcId=bc-01574f9c-fc80-41ac-ae8b-60a24ce425a8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-01574f9c-fc80-41ac-ae8b-60a24ce425a8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>